### PR TITLE
Fix C4018 warnings

### DIFF
--- a/script/cpp/src/tvgw_converter.cpp
+++ b/script/cpp/src/tvgw_converter.cpp
@@ -27,7 +27,7 @@ extern "C" TVGW_RIFF_File* tvgw_ConvertToRIFF(unsigned int fileType, unsigned in
     // Counted the word "WAVE"
     int fileSize = sizeof(unsigned int);
 
-    for(int counter = 0; counter < chunkCount; counter++){
+    for(unsigned int counter = 0; counter < chunkCount; counter++){
         fileSize += (sizeof(unsigned int) * 2 + chunks[counter]->chunkSize);
     }
 

--- a/script/cpp/src/tvgw_fileload.cpp
+++ b/script/cpp/src/tvgw_fileload.cpp
@@ -55,7 +55,7 @@ extern "C" int tvgw_LoadFileChunk(std::ifstream* fin, TVGW_File_Chunk* chunk){
         return -1;
     }
     else{
-        for(int i = 0; i < chunk->chunkSize; i++){
+        for(unsigned int i = 0; i < chunk->chunkSize; i++){
             fin->read(chunk->data + i, sizeof(char));
         }
     }

--- a/script/cpp/src/tvgw_filewrite.cpp
+++ b/script/cpp/src/tvgw_filewrite.cpp
@@ -8,7 +8,7 @@ extern "C" int tvgw_WriteFile(const char* filename, TVGW_RIFF_File* filedata){
 
     fout.write((char*)filedata, sizeof(unsigned int) * 3);
 
-    for(int counter = 0; counter < filedata->chunkCount; counter++){
+    for(unsigned int counter = 0; counter < filedata->chunkCount; counter++){
         tvgw_WriteFileChunk(&fout, filedata->chunks[counter]);
     }
 


### PR DESCRIPTION
```
##[warning]script\cpp\src\tvgw_converter.cpp(30,0): Warning C4018: '<': signed/unsigned mismatch
##[warning]script\cpp\src\tvgw_fileload.cpp(58,0): Warning C4018: '<': signed/unsigned mismatch
##[warning]script\cpp\src\tvgw_filewrite.cpp(11,0): Warning C4018: '<': signed/unsigned mismatch
##[warning]script\cpp\src\tvgw_converter.cpp(30,0): Warning C4018: '<': signed/unsigned mismatch
##[warning]script\cpp\src\tvgw_fileload.cpp(58,0): Warning C4018: '<': signed/unsigned mismatch
##[warning]script\cpp\src\tvgw_filewrite.cpp(11,0): Warning C4018: '<': signed/unsigned mismatch
```
I fixed them.